### PR TITLE
adding optional chaining in `process` object to avoid apps crash

### DIFF
--- a/dist/withRoundTrip.js
+++ b/dist/withRoundTrip.js
@@ -5,17 +5,24 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.withRoundTrip = void 0;
 var _clientApi = require("@storybook/client-api");
+
 var _constants = require("./constants");
+
 var _parseTicketData = _interopRequireDefault(require("./helpers/parseTicketData"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
 // something to have a look at:
 // https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn
-
 var withRoundTrip = function withRoundTrip(storyFn) {
   var _useChannel;
+
   var clearData = function clearData() {
     emit(_constants.EVENTS.RESULT, {
       overview: {},
@@ -23,6 +30,7 @@ var withRoundTrip = function withRoundTrip(storyFn) {
       data: {}
     });
   };
+
   var emit = (0, _clientApi.useChannel)((_useChannel = {}, _defineProperty(_useChannel, _constants.EVENTS.REQUEST, function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(_ref) {
       var ticketId, isForSubtask, data, _process, _process$env, fetchedData, parsedData;
@@ -32,18 +40,22 @@ var withRoundTrip = function withRoundTrip(storyFn) {
             case 0:
               ticketId = _ref.ticketId, isForSubtask = _ref.isForSubtask;
               data = null;
+
               if (!ticketId) {
                 _context.next = 9;
                 break;
               }
+
               _context.next = 5;
               return fetch("".concat(((_process = process) === null || _process === void 0 ? void 0 : (_process$env = _process.env) === null || _process$env === void 0 ? void 0 : _process$env.STORYBOOK_MIDDLEWARE_JIRA_ENDPOINT) || '/api', "?ticketId=").concat(ticketId));
             case 5:
               fetchedData = _context.sent;
               _context.next = 8;
               return fetchedData.json();
+
             case 8:
               data = _context.sent;
+
             case 9:
               parsedData = (0, _parseTicketData["default"])(data);
               emit(_constants.EVENTS.RESULT, {
@@ -57,10 +69,12 @@ var withRoundTrip = function withRoundTrip(storyFn) {
         }
       }, _callee);
     }));
+
     return function (_x) {
       return _ref2.apply(this, arguments);
     };
   }()), _defineProperty(_useChannel, _constants.EVENTS.CLEAR, clearData), _useChannel));
   return storyFn();
 };
+
 exports.withRoundTrip = withRoundTrip;

--- a/dist/withRoundTrip.js
+++ b/dist/withRoundTrip.js
@@ -4,26 +4,18 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.withRoundTrip = void 0;
-
 var _clientApi = require("@storybook/client-api");
-
 var _constants = require("./constants");
-
 var _parseTicketData = _interopRequireDefault(require("./helpers/parseTicketData"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
-
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
-
 // something to have a look at:
 // https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn
+
 var withRoundTrip = function withRoundTrip(storyFn) {
   var _useChannel;
-
   var clearData = function clearData() {
     emit(_constants.EVENTS.RESULT, {
       overview: {},
@@ -31,41 +23,33 @@ var withRoundTrip = function withRoundTrip(storyFn) {
       data: {}
     });
   };
-
   var emit = (0, _clientApi.useChannel)((_useChannel = {}, _defineProperty(_useChannel, _constants.EVENTS.REQUEST, function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(_ref) {
-      var ticketId, isForSubtask, data, _process$env, fetchedData, parsedData;
-
+      var ticketId, isForSubtask, data, _process, _process$env, fetchedData, parsedData;
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
               ticketId = _ref.ticketId, isForSubtask = _ref.isForSubtask;
               data = null;
-
               if (!ticketId) {
                 _context.next = 9;
                 break;
               }
-
               _context.next = 5;
-              return fetch("".concat(((_process$env = process.env) === null || _process$env === void 0 ? void 0 : _process$env.STORYBOOK_MIDDLEWARE_JIRA_ENDPOINT) || '/api', "?ticketId=").concat(ticketId));
-
+              return fetch("".concat(((_process = process) === null || _process === void 0 ? void 0 : (_process$env = _process.env) === null || _process$env === void 0 ? void 0 : _process$env.STORYBOOK_MIDDLEWARE_JIRA_ENDPOINT) || '/api', "?ticketId=").concat(ticketId));
             case 5:
               fetchedData = _context.sent;
               _context.next = 8;
               return fetchedData.json();
-
             case 8:
               data = _context.sent;
-
             case 9:
               parsedData = (0, _parseTicketData["default"])(data);
               emit(_constants.EVENTS.RESULT, {
                 parsedData: parsedData,
                 isForSubtask: isForSubtask
               });
-
             case 11:
             case "end":
               return _context.stop();
@@ -73,12 +57,10 @@ var withRoundTrip = function withRoundTrip(storyFn) {
         }
       }, _callee);
     }));
-
     return function (_x) {
       return _ref2.apply(this, arguments);
     };
   }()), _defineProperty(_useChannel, _constants.EVENTS.CLEAR, clearData), _useChannel));
   return storyFn();
 };
-
 exports.withRoundTrip = withRoundTrip;

--- a/dist/withRoundTrip.js
+++ b/dist/withRoundTrip.js
@@ -4,6 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.withRoundTrip = void 0;
+
 var _clientApi = require("@storybook/client-api");
 
 var _constants = require("./constants");

--- a/src/withRoundTrip.js
+++ b/src/withRoundTrip.js
@@ -18,7 +18,7 @@ export const withRoundTrip = (storyFn) => {
     [EVENTS.REQUEST]: async ({ ticketId, isForSubtask }) => {
       let data = null
       if (ticketId) {
-        const fetchedData = await fetch(`${process.env?.STORYBOOK_MIDDLEWARE_JIRA_ENDPOINT || '/api'}?ticketId=${ticketId}`)
+        const fetchedData = await fetch(`${process?.env?.STORYBOOK_MIDDLEWARE_JIRA_ENDPOINT || '/api'}?ticketId=${ticketId}`)
         data = await fetchedData.json()
       }
       const parsedData = parseTicketData(data)


### PR DESCRIPTION
fixes https://github.com/lennartdeknikker/storybook-addon-jira/issues/4

## Explanation

What I want to do in this PR is to handle the possibility of `process` object was undefined and avoid that app crash by that.

In my project it's failing because the `process` object is undefined, so by adding optional chaining to it, it works again and works fine since it can work properly with the default `/api`

## Screenshots

With this change:

![image](https://user-images.githubusercontent.com/66505715/211864840-c06211c7-b13b-4c3a-a283-90abb593b31b.png)

Without this change:

![image](https://user-images.githubusercontent.com/66505715/211864857-40d7be13-93df-42bd-bfcb-46763ad2ade9.png)
